### PR TITLE
Improve usage of the artifact folder

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,3 +2,5 @@
 set -ex
 
 dependency-check --failOnCVSS=$fail_on_cvss_level --enableExperimental --project $app_title --out $deploy_dir --scan $podfile_lock_path
+# Rename file to allow other dependency checker to be executed and stored in the artifact folder
+mv $deploy_dir/dependency-check-report.html $deploy_dir/cocoapods-dependency-check-report.html


### PR DESCRIPTION
If we would like to execute cocoa pods & Gradle dependency checker in the same build, like we can't specify a file name for the output, reports are overwritten.

This fix will allow https://github.com/odemolliens/bitrise-step-gradle-dependency-checker to works properly